### PR TITLE
Update airspeed requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'argparse',
         'pylems>=0.5.0',
-        'airspeed==0.5.4dev-20150515',
+        'airspeed>=0.5.5',
         'libNeuroML>=0.2.52',
         'neuromllite>=0.1.9',
         'kiwisolver<=1.1.0',


### PR DESCRIPTION
Airspeed is now at 0.5.16, so it's good to just let it be grater than
0.5.5 (unless we need to be at the specific 0.5.4 version?)

https://pypi.org/project/airspeed/