### PR TITLE
Use development branch of libNML in requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ NEURON
 ppft
 
 # change these to development if working on the development branch
-git+https://github.com/NeuralEnsemble/libNeuroML.git@master#egg=libNeuroML
+git+https://github.com/NeuralEnsemble/libNeuroML.git@development#egg=libNeuroML
 git+https://github.com/LEMS/pylems.git@master#egg=pylems
 
 


### PR DESCRIPTION
Needed so that nmllite tests pass. Defaulting to master libnml means a version less than the current required version for nmllite is used.

libNML dev will always be the latest and best tested, so probably not an issue when a dev install of pynml is required