### PR TITLE
Drop explicit inspyred installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,9 @@ jobs:
         echo "github.ref is: ${{ github.ref }}"
         echo "github.base_ref is: ${{ github.base_ref }}"
 
-    - name: Upgrade pip, install inspyred
+    - name: Upgrade pip, install deps
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/aarongarrett/inspyred.git@master#egg=inspyred
         pip install .[dev]
 
     - name: List packages so far


### PR DESCRIPTION
Requires a new release of neurotune.