### PR TITLE
fix(vispy): use proximal and distal radii for mesh

### DIFF
--- a/pyneuroml/plot/PlotMorphologyVispy.py
+++ b/pyneuroml/plot/PlotMorphologyVispy.py
@@ -724,10 +724,11 @@ def plot_3D_cell_morphology(
         length = cell.get_segment_length(seg.id)
 
         # round up to precision
-        r = round(p.diameter / 2, mesh_precision)
+        r1 = round(p.diameter / 2, mesh_precision)
+        r2 = round(d.diameter / 2, mesh_precision)
         key = (
-            f"{r:.{mesh_precision}f}",
-            f"{r:.{mesh_precision}f}",
+            f"{r1:.{mesh_precision}f}",
+            f"{r2:.{mesh_precision}f}",
             f"{round(length, mesh_precision):.{mesh_precision}f}",
         )
 


### PR DESCRIPTION
During refactoring, we'd used only the one radii, but that meant we only got cylinders, not cones and other related shapes where the two radii can be different.

Note that this means there may be more unique meshes, and so, the precision may be reduced more by the heuristic. But, it will allow users with more computing power to get more accurate meshes.