### PR TITLE
feat: split vispy into qt5 and qt6 deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,13 +89,21 @@ tune =
     neurotune>=0.2.6
     ppft
 
-vispy =
+vispy-common =
     vispy>=0.13.0
     scipy
     pyopengl
     PyOpenGL-accelerate
-    pyqt6
     progressbar2
+
+vispy-qt5 =
+    pyNeuroML[vispy-common]
+    pyqt5
+
+# default is qt6
+vispy =
+    pyNeuroML[vispy-common]
+    pyqt6
 
 plotly =
     plotly


### PR DESCRIPTION
Use qt6 by default, but allow users to install the qt5 version too. This is just to support systems that may not use qt6 yet.