### PR TITLE
More annotation tweaks: remove unused ids, use `rdf:li` 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,4 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.1
   hooks:
-    - id: ruff
-      args: [ --exit-zero ]
     - id: ruff-format


### PR DESCRIPTION
These work better with LEMS, since we need to define the LEMS component  types completely