### PR TITLE
feat(rotation): allow users to pick if they want a copy

### DIFF
--- a/pyneuroml/utils/__init__.py
+++ b/pyneuroml/utils/__init__.py
@@ -327,10 +327,10 @@ def get_state_color(s: str) -> str:
     if s.startswith("u"):
         col = "#880088"
 
-    if '/' in s: # e.g. for sub gates
+    if "/" in s:  # e.g. for sub gates
         from pyneuroml.utils.plot import get_next_hex_color
-        col = get_next_hex_color()
 
+        col = get_next_hex_color()
 
     return col
 
@@ -342,6 +342,7 @@ def rotate_cell(
     z: float = 0,
     order: str = "xyz",
     relative_to_soma: bool = False,
+    inplace: bool = False,
 ) -> neuroml.Cell:
     """Return a new cell object rotated in the provided order along the
     provided angles (in radians) relative to the soma position.
@@ -358,6 +359,10 @@ def rotate_cell(
     :type order: str
     :param relative_to_soma: whether rotation is relative to soma
     :type relative_to_soma: bool
+    :param inplace: toggle whether the cell object should be modified inplace
+        or a copy created (creates and returns a copy by default)
+
+    :type inplace: bool
     :returns: new neuroml.Cell object
     :rtype: neuroml.Cell
 
@@ -374,7 +379,12 @@ def rotate_cell(
     cell_origin = numpy.array(
         [soma_seg.proximal.x, soma_seg.proximal.y, soma_seg.proximal.z]
     )
-    newcell = copy.deepcopy(cell)
+
+    if not inplace:
+        newcell = copy.deepcopy(cell)
+    else:
+        newcell = cell
+
     print(f"Rotating {newcell.id} by {x}, {y}, {z}")
 
     # calculate rotations


### PR DESCRIPTION
Adds an option to allow users to rotate cell without creating a copy. 

@lej0hn : can do this in the translate function too, so that if the two operations are run one after the other, we don't need to create a copy each time.