### PR TITLE
feat: remove numpy version pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers=
     License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     graphviz
     typing; python_version<"3.5"
     lxml
-    numpy<2.0.0
+    numpy
     sympy
     ppft[dill]
 


### PR DESCRIPTION
Pytables now supports numpy>2.x

https://github.com/PyTables/PyTables/releases/tag/v3.10.1