### PR TITLE
fix: drop unused import

### DIFF
--- a/pyneuroml/neuron/analysis/HHanalyse.py
+++ b/pyneuroml/neuron/analysis/HHanalyse.py
@@ -14,6 +14,7 @@ from math import log
 
 import matplotlib.pyplot as pylab
 import neuron
+from pylab import plt
 
 from pyneuroml.utils import get_state_color
 from pyneuroml.utils.cli import build_namespace
@@ -378,8 +379,10 @@ def run(a=None, **kwargs):
                                         initSlopeVal[s],
                                         rateVal,
                                         h.t - timeToCheckTau,
-                                        fractOfInit,
-                                        log(fractOfInit),
+                                        # fractOfInit undefined, since initSlopeVal[s] == 0
+                                        "NA",
+                                        # log(fractOfInit) undefined, since initSlopeVal[s] == 0
+                                        "NA",
                                         tau,
                                     )
                                 )

--- a/pyneuroml/neuron/analysis/HHanalyse.py
+++ b/pyneuroml/neuron/analysis/HHanalyse.py
@@ -14,7 +14,6 @@ from math import log
 
 import matplotlib.pyplot as pylab
 import neuron
-from pylab import *
 
 from pyneuroml.utils import get_state_color
 from pyneuroml.utils.cli import build_namespace


### PR DESCRIPTION
This was somehow causing errors where instead of looking for `List` in `typing`, it was looking for `List` in `numpy.typing`---pylab must import it somewhere.

For reference, here's the complete traceback:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.12/x64/bin/pynml-modchananalysis", line 5, in <module>
    from pyneuroml.neuron.analysis.HHanalyse import main
  File "/opt/hostedtoolcache/Python/3.11.12/x64/lib/python3.11/site-packages/pyneuroml/neuron/analysis/HHanalyse.py", line 141, in <module>
    def get_states(txt: str) -> typing.List[str]:
                                ^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.12/x64/lib/python3.11/site-packages/numpy/typing/__init__.py", line 189, in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
AttributeError: module 'numpy.typing' has no attribute 'List'
```

@pgleeson we can revert/drop 6d4d21c in the experimental branch