### PR TITLE
feat(deps): unpin pyopengl-acclerate

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ vispy-common =
     vispy>=0.13.0
     scipy
     pyopengl
-    PyOpenGL-accelerate; python_version<"3.12"
+    PyOpenGL-accelerate
     scikit-learn
     frozendict
 


### PR DESCRIPTION
The latest version provides wheels up to py3.13 now

https://pypi.org/project/PyOpenGL-accelerate/3.1.9/#files