### PR TITLE
fix: remove unreachable elif branch in run_lems_with_eden

### DIFF
--- a/pyneuroml/runners.py
+++ b/pyneuroml/runners.py
@@ -661,8 +661,6 @@ def run_lems_with_eden(
     if load_saved_data:
         logger.warning("Event saving is not yet supported in EDEN!!")
         return results, {}
-    elif load_saved_data:
-        return results
     else:
         return True
 


### PR DESCRIPTION
The elif block checking 'load_saved_data' was unreachable because the if statement above it checks the exact same condition. This removes the dead code to clean up the logic.

#fix 460
